### PR TITLE
feat: Rework entity icon and raised buttons, disable Mat Typography

### DIFF
--- a/Explorer/src/app/feature-modules/administration/equipment-form/equipment-form.component.html
+++ b/Explorer/src/app/feature-modules/administration/equipment-form/equipment-form.component.html
@@ -1,10 +1,10 @@
 <form [formGroup]="equipmentForm">
     <div id="entity-form">
-        <mat-form-field class="entity-mat-mdc-form-field">
+        <mat-form-field id="entity-mat-mdc-form-field">
             <mat-label>Name</mat-label>
             <input matInput formControlName="name" type="text"/>
         </mat-form-field>
-        <mat-form-field class="entity-mat-mdc-form-field">
+        <mat-form-field id="entity-mat-mdc-form-field">
             <mat-label>Description</mat-label>
             <textarea matInput
             cdkTextareaAutosize

--- a/Explorer/src/index.html
+++ b/Explorer/src/index.html
@@ -13,7 +13,7 @@
 
 
 </head>
-<body class="mat-typography">
+<body >
   <app-root></app-root>
 </body>
 </html>

--- a/Explorer/src/styles.css
+++ b/Explorer/src/styles.css
@@ -23,12 +23,37 @@
 }
 
 #entity-icon-button{
+    color: #ffffff;
+    background-color: #2e003e;
+    transition: background-color 0.3s, color 0.3s;  
+    margin: 0.5vw;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+#entity-icon-button:hover{
     color:#2e003e;
+    background-color: #ffffff;
 }
 
 #entity-raised-button{
     color: #ffffff;
     background-color: #2e003e;
+    transition: background-color 0.3s, color 0.3s;    
+    padding: 0.5vw;
+    width: 100%;
+    height: 100%;
+
+}
+
+#entity-raised-button:hover{
+    color:#2e003e;
+    background-color: #ffffff;
+}
+
+body { 
+    margin: 0; font-family: Roboto, "Helvetica Neue", sans-serif; 
 }
 
 h1,h2,h3,h4,h5,h6 {
@@ -79,7 +104,20 @@ hr {
     border: 0.5px solid #2e003e;
 }
 
-.mat-icon {
+button {
+    background-color: #2e003e;
+    color: #ffffff;
+    transition: background-color 0.3s, color 0.3s;    
+}
+
+button {
+    background-color: #ffffff;
+    color: #2e003e;
+}
+
+
+/* CSS Classes for Mat Form fields, not functional */
+/* .mat-icon {
     vertical-align: middle;
 }
 
@@ -108,22 +146,29 @@ hr {
     margin: 5px;
     text-align: left;
     flex: 1;
-}
+} */
 
 
 .mat-mdc-raised-button.mat-primary {
-    background-color: #2e003e
-    
+    background-color: #2e003e;
+    color: #ffffff;
+    transition: background-color 0.3s, color 0.3s;    
 }
 
-body { margin: 0; font-family: Roboto, "Helvetica Neue", sans-serif; }
-
-@font-face {
-    font-family: Montserrat;
-    src: url(assets/fonts/Montserrat-Regular.ttf) format('truetype');
+.mat-mdc-raised-button.mat-primary:hover {
+    background-color: #ffffff;
+    color: #2e003e;
 }
 
 .Monserrat{
     font-family: Montserrat;
 
+}
+
+
+
+
+@font-face {
+    font-family: Montserrat;
+    src: url(assets/fonts/Montserrat-Regular.ttf) format('truetype');
 }


### PR DESCRIPTION
In the commit, CSS for entities icon and raised button was modified, mat-typography in the body of index.html was removed to ease the css modification of front-end